### PR TITLE
Correcting Route for Magic Links

### DIFF
--- a/src/main/java/com/bitwarden/passwordless/PasswordlessClientImpl.java
+++ b/src/main/java/com/bitwarden/passwordless/PasswordlessClientImpl.java
@@ -110,7 +110,7 @@ class PasswordlessClientImpl implements PasswordlessClient {
     public void sendMagicLink(SendMagicLinkOptions options) throws PasswordlessApiException, IOException {
         Objects.requireNonNull(options, "options cannot be null");
 
-        ClassicHttpRequest request = passwordlessHttpClient.createPostRequest("magic-link/send", options);
+        ClassicHttpRequest request = passwordlessHttpClient.createPostRequest("magic-links/send", options);
 
         passwordlessHttpClient.sendRequest(request, null);
     }

--- a/src/test/java/com/bitwarden/passwordless/PasswordlessClientImplTest.java
+++ b/src/test/java/com/bitwarden/passwordless/PasswordlessClientImplTest.java
@@ -372,7 +372,7 @@ class PasswordlessClientImplTest {
 
     @Test
     void sendMagicLink_validRequest_validResponse() throws PasswordlessApiException, IOException {
-        wireMock.stubFor(post(urlEqualTo("/magic-link/send"))
+        wireMock.stubFor(post(urlEqualTo("/magic-links/send"))
                 .willReturn(WireMock.ok()));
 
         SendMagicLinkOptions request = DataFactory.sendMagicLinkRequest();
@@ -384,7 +384,7 @@ class PasswordlessClientImplTest {
     void sendMagicLink_errorResponse_PasswordlessApiException() throws JsonProcessingException {
         PasswordlessProblemDetails problemDetails = DataFactory.passwordlessProblemDetailsInvalidToken();
 
-        wireMock.stubFor(post(urlEqualTo("/magic-link/send"))
+        wireMock.stubFor(post(urlEqualTo("/magic-links/send"))
                 .willReturn(wireMockUtils.createProblemDetailsResponse(problemDetails)));
 
         SendMagicLinkOptions request = DataFactory.sendMagicLinkRequest();


### PR DESCRIPTION
It was decided to change the route from `/magic-link/send` to `/magic-links/send`