### PR TITLE
Don't allow logback-classic to upgrade beyond 1.3.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>bitwarden/renovate-config"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["ch.qos.logback:logback-classic"],
+      "allowedVersions": "<=1.3.x",
+      "versioning": "semver"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bitwarden/renovate-config"],
-}


### PR DESCRIPTION
We don't want Renovate to upgrade/update the logback-classic dependency beyond 1.3.x as it is compiled with a more recent Java version.