### PR TITLE
[BRE-831] migrate secrets AKV

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -57,14 +57,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-passwordless-java
           secrets: "GPG-KEY,GPG-PASSPHRASE,OSSRH-USERNAME,OSSRH-TOKEN"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - id: install-secret-key

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -48,11 +49,29 @@ jobs:
             exit 1
           fi
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-passwordless-java
+          secrets: "GPG_KEY,GPG_PASSPHRASE,OSSRH_USERNAME,OSSRH_TOKEN"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
+
       - id: install-secret-key
         name: Import GPG Secret Key
         run: |
           # Install gpg secret key
-          cat <(echo -e "${{ secrets.GPG_KEY }}") | gpg --batch --import
+          cat <(echo -e "${{ steps.get-kv-secrets.outputs.GPG_KEY }}") | gpg --batch --import
           
           # Verify gpg secret key
           gpg --list-secret-keys --keyid-format LONG
@@ -62,8 +81,8 @@ jobs:
           mvn \
             --batch-mode \
             -Dmaven.test.skip \
-            -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} \
+            -Dgpg.passphrase=${{ steps.get-kv-secrets.outputs.GPG_PASSPHRASE }} \
             clean deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ steps.get-kv-secrets.outputs.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ steps.get-kv-secrets.outputs.OSSRH_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,7 +57,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,6 @@ jobs:
           fi
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,7 @@ jobs:
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-passwordless-java
-          secrets: "GPG_KEY,GPG_PASSPHRASE,OSSRH_USERNAME,OSSRH_TOKEN"
+          secrets: "GPG-KEY,GPG-PASSPHRASE,OSSRH-USERNAME,OSSRH-TOKEN"
 
       - name: Azure Logout
         uses: bitwarden/gh-actions/azure-logout@main
@@ -71,7 +71,7 @@ jobs:
         name: Import GPG Secret Key
         run: |
           # Install gpg secret key
-          cat <(echo -e "${{ steps.get-kv-secrets.outputs.GPG_KEY }}") | gpg --batch --import
+          cat <(echo -e "${{ steps.get-kv-secrets.outputs.GPG-KEY }}") | gpg --batch --import
           
           # Verify gpg secret key
           gpg --list-secret-keys --keyid-format LONG
@@ -81,8 +81,8 @@ jobs:
           mvn \
             --batch-mode \
             -Dmaven.test.skip \
-            -Dgpg.passphrase=${{ steps.get-kv-secrets.outputs.GPG_PASSPHRASE }} \
+            -Dgpg.passphrase=${{ steps.get-kv-secrets.outputs.GPG-PASSPHRASE }} \
             clean deploy
         env:
-          MAVEN_USERNAME: ${{ steps.get-kv-secrets.outputs.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ steps.get-kv-secrets.outputs.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ steps.get-kv-secrets.outputs.OSSRH-USERNAME }}
+          MAVEN_PASSWORD: ${{ steps.get-kv-secrets.outputs.OSSRH-TOKEN }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: ${{  github.event.pull_request.head.sha }}
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -49,14 +49,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "CHECKMARX-TENANT,CHECKMARX-CLIENT-ID,CHECKMARX-SECRET"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Scan with Checkmarx
@@ -103,7 +103,7 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -111,14 +111,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "SONAR-TOKEN"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Scan with SonarCloud

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -42,7 +42,6 @@ jobs:
           ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -104,7 +103,6 @@ jobs:
           distribution: "temurin"
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,13 +7,21 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches-ignore:
+      - main
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
 
 jobs:
   check-run:
     name: Check PR run
     uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+    permissions:
+      contents: read
 
   sast:
     name: SAST scan
@@ -23,6 +31,7 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
 
     steps:
       - name: Check out repo
@@ -30,16 +39,34 @@ jobs:
         with:
           ref: ${{  github.event.pull_request.head.sha }}
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "CHECKMARX-TENANT,CHECKMARX-CLIENT-ID,CHECKMARX-SECRET"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
+
       - name: Scan with Checkmarx
         uses: checkmarx/ast-github-action@629a9fac14369bf2898d583b22bf8c40a5caf8e9 # 2.0.40
         env:
           INCREMENTAL: "${{ contains(github.event_name, 'pull_request') && '--sast-incremental' || '' }}"
         with:
           project_name: ${{ github.repository }}
-          cx_tenant: ${{ secrets.CHECKMARX_TENANT }}
+          cx_tenant: ${{ steps.get-kv-secrets.outputs.CHECKMARX-TENANT }}
           base_uri: https://ast.checkmarx.net/
-          cx_client_id: ${{ secrets.CHECKMARX_CLIENT_ID }}
-          cx_client_secret: ${{ secrets.CHECKMARX_SECRET }}
+          cx_client_id: ${{ steps.get-kv-secrets.outputs.CHECKMARX-CLIENT-ID }}
+          cx_client_secret: ${{ steps.get-kv-secrets.outputs.CHECKMARX-SECRET }}
           additional_params: |
             --report-format sarif \
             --filter "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT" \
@@ -59,6 +86,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Check out repo
@@ -73,8 +101,26 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "SONAR-TOKEN"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
+
       - name: Scan with SonarCloud
         env:
-            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+            SONAR_TOKEN: ${{ steps.get-kv-secrets.outputs.SONAR-TOKEN }}
         run: mvn clean install -Dgpg.skip=true sonar:sonar ${{ contains(github.event_name, 'pull_request') && format('-Dsonar.pullrequest.key={0}', github.event.pull_request.number) || '' }}
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -49,7 +49,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
@@ -111,7 +111,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-831](https://bitwarden.atlassian.net/browse/BRE-831)

## 📔 Objective

Updating to use Azure Key Vault Secrets in place of GitHub secrets.
All GitHub secrets have been migrated to the repository's respective Key Vault.
Azure Service Principals have been updated to use Managed Identities with OIDC.

[BRE-831]: https://bitwarden.atlassian.net/browse/BRE-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ