### PR TITLE
[PM-42223] deps: Bump spring-boot-starter-parent to 3.5.16 in passwordless-java example

### DIFF
--- a/examples/spring-boot-3-jdk-17/pom.xml
+++ b/examples/spring-boot-3-jdk-17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.3</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.bitwarden</groupId>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.2.0</version>
+            <version>2.8.17</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-boot-3-jdk-17/pom.xml
+++ b/examples/spring-boot-3-jdk-17/pom.xml
@@ -19,6 +19,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <lombok.version>1.18.38</lombok.version>
+        <!-- Override the parent's managed Jackson version: 3.5.16 pins jackson-bom 2.21.4,
+             which carries 2 medium CVEs fixed in 2.21.5. -->
+        <jackson-bom.version>2.22.2</jackson-bom.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Ticket
- Closes [PM-42223](https://bitwarden.atlassian.net/browse/PM-42223)

### Description
Bumps `spring-boot-starter-parent` 3.1.3 → 3.5.16 in the `examples/spring-boot-3-jdk-17` sample app to fix CVE-2022-1471 (snakeyaml). Same bump also clears transitive Tomcat and Thymeleaf advisories on the same pom.

`springdoc-openapi-starter-webmvc-ui` is bumped 2.2.0 → 2.8.17 alongside it, since 2.2.0 predates Spring Boot's `PathPatternParser`-by-default change in 3.2+ and would break Swagger UI otherwise.

### Shape
Dependency-only change, no source touched. This is the unpublished sample app, not the published SDK.

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- `./mvnw compile`/`test` pass; `dependency:tree` confirms `snakeyaml 2.4`, `tomcat-embed 10.1.55`, `thymeleaf 3.1.5.RELEASE`
- Ran the app live; `/`, `/swagger-ui/index.html`, `/v3/api-docs` all return 200 with correct content

I did the following to ensure that my changes do not introduce security vulnerabilities:
- This change is itself a vulnerability remediation
- Local code review (`bitwarden-code-reviewer`) — Approved


[PM-42223]: https://bitwarden.atlassian.net/browse/PM-42223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-898]: https://bitwarden.atlassian.net/browse/VULN-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-896]: https://bitwarden.atlassian.net/browse/VULN-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-897]: https://bitwarden.atlassian.net/browse/VULN-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ